### PR TITLE
mongodb-memory-server 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "jsonwebtoken": "^9.0.2",
         "micro": "^10.0.1",
         "module-alias": "^2.2.3",
-        "mongodb-memory-server": "^9.4.1",
+        "mongodb-memory-server": "^10.0.0",
         "mongoose": "^8.5.3",
         "newrelic": "^12.1.1",
         "next": "^14.2.5",
@@ -7403,9 +7403,9 @@
       "license": "MIT"
     },
     "node_modules/async-mutex": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
-      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -12245,6 +12245,8 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -12257,7 +12259,9 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -14818,7 +14822,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -15625,59 +15631,40 @@
       }
     },
     "node_modules/mongodb-memory-server": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.4.1.tgz",
-      "integrity": "sha512-qONlW4sKPbtk9pqFnlPn7R73G3Q4TuebJJ5pHfoiKTqVJquojQ8xWmkCyz+/YnpA2vYBo/jib+nXvjfKwh7cjg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.0.0.tgz",
+      "integrity": "sha512-7Geo/s4lst/QHw+N8/stdnyb08xn68O0zbSee62jgoPfWOXfSPhX9a8OvyOY/o23oYk9ra2EpA2Oejenb3JKfw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "mongodb-memory-server-core": "9.4.1",
+        "mongodb-memory-server-core": "10.0.0",
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/mongodb-memory-server-core": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.4.1.tgz",
-      "integrity": "sha512-lobapXaysH64zrn521NTkmqHc3krSPUFkuuZ8A/BmQV8ON7p2SzAEvpoJPDXIeJkxIzYw06dYL6Gn5OcZdEElA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.0.0.tgz",
+      "integrity": "sha512-AdYi4nVqe3Pk95fRJ+DegbDdEfAG9wujNsVvJWbwh8+ZJd+d3JJK1PHxRyJ9rMvoczvlli5M30eMig7zBuF5pQ==",
       "license": "MIT",
       "dependencies": {
-        "async-mutex": "^0.4.1",
+        "async-mutex": "^0.5.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.5",
         "find-cache-dir": "^3.3.2",
         "follow-redirects": "^1.15.6",
-        "https-proxy-agent": "^7.0.4",
-        "mongodb": "^5.9.2",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.7.0",
         "new-find-package-json": "^2.0.0",
-        "semver": "^7.6.2",
+        "semver": "^7.6.3",
         "tar-stream": "^3.1.7",
         "tslib": "^2.6.3",
         "yauzl": "^3.1.3"
       },
       "engines": {
-        "node": ">=14.20.1"
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/bson": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
@@ -15692,57 +15679,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
-      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -15753,31 +15689,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-memory-server-core/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/mongoose": {
@@ -18304,6 +18215,8 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -18391,6 +18304,8 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^9.0.2",
     "micro": "^10.0.1",
     "module-alias": "^2.2.3",
-    "mongodb-memory-server": "^9.4.1",
+    "mongodb-memory-server": "^10.0.0",
     "mongoose": "^8.5.3",
     "newrelic": "^12.1.1",
     "next": "^14.2.5",


### PR DESCRIPTION
the tests run extremely slow for me locally with this update

wondering if it's because `tsconfig: potentially breaking change upgrading "target" to "es2021" in tsconfig` here: https://github.com/typegoose/mongodb-memory-server/releases/tag/v10.0.0