### PR TITLE
Adjust game display for mobile multiplayer

### DIFF
--- a/pages/[subdomain]/match/[matchId]/index.tsx
+++ b/pages/[subdomain]/match/[matchId]/index.tsx
@@ -365,7 +365,7 @@ export default function Match({ initialMatch }: MatchProps) {
         <div className={classNames('relative max-w-7xl mx-auto px-2 sm:px-4 lg:px-6', {
           'py-4 sm:py-8': !(matchInProgress && iAmPlaying),
           'h-full flex flex-col': matchInProgress && iAmPlaying
-        })} style={{ minHeight: matchInProgress && iAmPlaying ? '800px' : 'auto' }}>
+        })} style={{ minHeight: matchInProgress && iAmPlaying ? '0' : 'auto' }}>
 
           <MatchHeader matchInProgress={matchInProgress} prettyMatchState={prettyMatchState} />
 


### PR DESCRIPTION
Set match page container `minHeight` to `0` during active play to prevent mobile overflow when fullscreen.

The previous `800px` minimum height on the match page container caused game controls to go past the bottom of the screen on mobile devices when the page was in fullscreen mode with scrolling disabled. This change allows the game content to shrink and fit within the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f1cab7d-423e-48e0-a157-57337432155e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f1cab7d-423e-48e0-a157-57337432155e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

