### PR TITLE
Fix level editor drag click issue

### DIFF
--- a/components/level/basicLayout.tsx
+++ b/components/level/basicLayout.tsx
@@ -44,13 +44,13 @@ export default function BasicLayout({ cellClassName, cellStyle, controls, hideTe
             onClick(index, rightClick);
           }
         } : undefined}
-        onCellClick={!deviceInfo.isMobile ? (x, y, rightClick) => {
+        onCellClick={(x, y, rightClick) => {
           if (onClick) {
             const index = y * (level.width + 1) + x;
 
             onClick(index, rightClick);
           }
-        } : undefined}
+        }}
 
       />
       {!controls ? null : <Controls controls={controls} />}


### PR DESCRIPTION
Always wire `onCellClick` to enable regular clicks on desktop in the level editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ed75dfa-79c7-4ace-be11-51a7033f143a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ed75dfa-79c7-4ace-be11-51a7033f143a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

